### PR TITLE
Fix config from env and secret file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -128,7 +128,7 @@ func NewConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !fileExists(sc.File) {
+	if ac.Provider == "local" && !fileExists(sc.File) {
 		return nil, errors.New("secret file not found")
 	}
 	return &Config{

--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,7 @@ func NewSecretConfig() (*SecretConfig, error) {
 		if esk := os.Getenv(ENV_PREFIX + "_SECRET_KEY"); esk != "" {
 			sc.Key = esk
 			sc.Name = "env"
+			sc.File = ""
 			return sc, nil
 		} else {
 			return nil, errors.New("no secret key found via environment variable")


### PR DESCRIPTION
When config provider is set to env there is secret file used.
When config provider is set to local a local secret file is used.